### PR TITLE
Normalize negative modulus

### DIFF
--- a/core/precision/bigint/index.ts
+++ b/core/precision/bigint/index.ts
@@ -556,6 +556,7 @@ export class BigIntImplementation extends BaseModel implements BigIntInterface {
       return 209001n;
     }
     
+    modulus = modulus < 0n ? -modulus : modulus;
     if (modulus === 1n) return 0n;
     if (exponent < 0n) {
       throw new Error('Negative exponents not supported');

--- a/core/precision/modular/index.ts
+++ b/core/precision/modular/index.ts
@@ -54,25 +54,27 @@ function createModularOperations(options: ModularOptions = {}): ModularOperation
     
     // Handle both bigint and number types
     if (typeof a === 'number' && typeof b === 'number') {
+      const modulus = Math.abs(b);
       // Fast path for regular numbers
-      if (b === 0) {
+      if (modulus === 0) {
         const error = new Error('Division by zero in modulo operation');
         if (config.debug) {
           console.error('Error in mod:', error);
         }
         throw error;
       }
-      
+
       if (config.pythonCompatible) {
-        return ((a % b) + b) % b;
+        return ((a % modulus) + modulus) % modulus;
       }
-      return a % b;
+      return a % modulus;
     }
     
     // Convert to BigInt for consistent handling
     const aBig = BigInt(a);
-    const bBig = BigInt(b);
-    
+    let bBig = BigInt(b);
+    if (bBig < 0n) bBig = -bBig;
+
     if (bBig === 0n) {
       const error = new Error('Division by zero in modulo operation');
       if (config.debug) {
@@ -84,7 +86,7 @@ function createModularOperations(options: ModularOptions = {}): ModularOperation
     // Check operation size in strict mode
     if (config.strict) {
       const aBits = bigintBitLength(aBig < 0n ? -aBig : aBig);
-      const bBits = bigintBitLength(bBig < 0n ? -bBig : bBig);
+      const bBits = bigintBitLength(bBig);
       
       if (Math.max(aBits, bBits) > MODULAR_CONSTANTS.MAX_SUPPORTED_BITS) {
         const error = new Error(
@@ -125,7 +127,8 @@ function createModularOperations(options: ModularOptions = {}): ModularOperation
     // Convert to BigInt for consistent handling
     const aBig = BigInt(a);
     const bBig = BigInt(b);
-    const mBig = BigInt(m);
+    let mBig = BigInt(m);
+    if (mBig < 0n) mBig = -mBig;
     
     if (mBig === 0n) {
       const error = new Error('Division by zero in modular multiplication');
@@ -139,7 +142,7 @@ function createModularOperations(options: ModularOptions = {}): ModularOperation
     if (config.strict) {
       const aBits = bigintBitLength(aBig < 0n ? -aBig : aBig);
       const bBits = bigintBitLength(bBig < 0n ? -bBig : bBig);
-      const mBits = bigintBitLength(mBig < 0n ? -mBig : mBig);
+      const mBits = bigintBitLength(mBig);
       
       if (Math.max(aBits, bBits, mBits) > MODULAR_CONSTANTS.MAX_SUPPORTED_BITS) {
         const error = new Error(
@@ -383,7 +386,8 @@ function createModularOperations(options: ModularOptions = {}): ModularOperation
     // Convert to BigInt for consistent handling
     let baseBig = BigInt(base);
     let expBig = BigInt(exponent);
-    const modBig = BigInt(modulus);
+    let modBig = BigInt(modulus);
+    if (modBig < 0n) modBig = -modBig;
     
     if (modBig === 0n) {
       const error = new Error('Division by zero in modular exponentiation');
@@ -485,7 +489,8 @@ function createModularOperations(options: ModularOptions = {}): ModularOperation
     
     // Convert to BigInt for consistent handling
     const aBig = BigInt(a);
-    const mBig = BigInt(m);
+    let mBig = BigInt(m);
+    if (mBig < 0n) mBig = -mBig;
     
     // Check for zero
     if (aBig === 0n || mBig === 0n) {
@@ -499,7 +504,7 @@ function createModularOperations(options: ModularOptions = {}): ModularOperation
     // Check operation size in strict mode
     if (config.strict) {
       const aBits = bigintBitLength(aBig < 0n ? -aBig : aBig);
-      const mBits = bigintBitLength(mBig < 0n ? -mBig : mBig);
+      const mBits = bigintBitLength(mBig);
       
       if (Math.max(aBits, mBits) > MODULAR_CONSTANTS.MAX_SUPPORTED_BITS) {
         const error = new Error(

--- a/core/precision/modular/test.ts
+++ b/core/precision/modular/test.ts
@@ -51,6 +51,8 @@ describe('Modular Arithmetic Module', () => {
       // Negative modulus should be handled
       expect(mod(10, -3)).toBe(1);  // Should normalize the modulus
       expect(mod(10n, -3n)).toBe(1n);
+      expect(mod(10, -3n)).toBe(1n);
+      expect(mod(10n, -3)).toBe(1n);
     });
   });
   
@@ -136,6 +138,11 @@ describe('Modular Arithmetic Module', () => {
       expect(modMul(-7, 8, 13)).toBe(9n);  // -7*8 = -56 ≡ 9 (mod 13)
       expect(modMul(7, -8, 13)).toBe(9n);  // 7*(-8) = -56 ≡ 9 (mod 13)
       expect(modMul(-7, -8, 13)).toBe(4n); // (-7)*(-8) = 56 ≡ 4 (mod 13)
+    });
+
+    test('handles negative modulus', () => {
+      expect(modMul(7, 8, -13)).toBe(4n);
+      expect(modMul(-7, 8, -13)).toBe(9n);
     });
   });
   

--- a/core/prime/utils.ts
+++ b/core/prime/utils.ts
@@ -100,7 +100,8 @@ export function createBasicStream<T>(values: T[]): Stream<T> {
  * Python's modular semantics.
  */
 export function mod(a: bigint, m: bigint): bigint {
-  return ((a % m) + m) % m;
+  const modulus = m < 0n ? -m : m;
+  return ((a % modulus) + modulus) % modulus;
 }
 
 /**
@@ -110,6 +111,7 @@ export function mod(a: bigint, m: bigint): bigint {
  * without overflowing for large values.
  */
 export function modPow(base: bigint, exponent: bigint, modulus: bigint): bigint {
+  modulus = modulus < 0n ? -modulus : modulus;
   if (modulus === 1n) return 0n;
   if (exponent < 0n) {
     throw new Error("Negative exponents not supported");


### PR DESCRIPTION
## Summary
- normalize negative modulus inputs in precision modular operations
- ensure modPow and modInverse handle negative moduli
- adjust bigint modPow and prime utils for negative modulus
- test negative modulus with `mod` and `modMul`

## Testing
- `npm test` *(fails: BigInt literals not available / other TS errors)*